### PR TITLE
fix(provider): return error for missing connection

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -250,5 +250,10 @@ func (h *Handler) getCollectionFromContext(ctx context.Context) (*gocb.Collectio
 		h.Logger.Warn("Received request from unlinked source", "sourceId", sourceId)
 		return nil, errors.New("received request from unlinked source")
 	}
-	return h.clusterConnections[sourceId], nil
+	connection := h.clusterConnections[sourceId]
+	if connection == nil {
+		h.Logger.Warn("Received request from unlinked source", "sourceId", sourceId)
+		return nil, errors.New("received request from unlinked source")
+	}
+	return connection, nil
 }

--- a/wadm.yaml
+++ b/wadm.yaml
@@ -72,7 +72,7 @@ spec:
     - name: httpserver
       type: capability
       properties:
-        image: ghcr.io/wasmcloud/http-server:0.22.0
+        image: ghcr.io/wasmcloud/http-server:0.26.0
       traits:
         # Link the httpserver to the component, and configure the HTTP server
         # to listen on port 8080 for incoming requests
@@ -82,6 +82,7 @@ spec:
             namespace: wasi
             package: http
             interfaces: [incoming-handler]
+            name: rust
             source:
               config:
                 - name: 8080-http
@@ -93,6 +94,7 @@ spec:
             namespace: wasi
             package: http
             interfaces: [incoming-handler]
+            name: go
             source:
               config:
                 - name: 8081-http


### PR DESCRIPTION
This PR fixes an issue where we could return `nil` for a connection pointer instead of an error when a connection isn't present. Since the connection is still a pointer it could still be `nil`, but will only be nil when an error is present.